### PR TITLE
Throw error when maxlength attribut is undefined or lower than 0

### DIFF
--- a/bootstrap-maxlength.js
+++ b/bootstrap-maxlength.js
@@ -3,8 +3,8 @@
     $(this).each(function() {
       var max = $(this).attr('maxlength');
 
-      if (max <= 0) {
-        return;
+      if (max <= 0 || max === undefined) {
+        throw new Error('maxlength attribut must be defined and higher than 0');
       }
 
       if (!$(this).parent().hasClass('input-group')) {


### PR DESCRIPTION
Hi,

I think it's important to notice users when they don't use the plugin in a right way.
